### PR TITLE
Fixed inclusion error

### DIFF
--- a/src/core/vlcplayer.cpp
+++ b/src/core/vlcplayer.cpp
@@ -1,3 +1,4 @@
+#include "stdio.h"
 #include "vlcplayer.h"
 #include <vlc/vlc.h>
 #include <QTimer>


### PR DESCRIPTION
stdio.h was not included in this file, and compilation failes.
